### PR TITLE
Add gist indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ out/
 
 # Generated Prisma Client
 prisma/generated
+
+.vscode

--- a/prisma/migrations/20250715090455_pg_trgm_extension/migration.sql
+++ b/prisma/migrations/20250715090455_pg_trgm_extension/migration.sql
@@ -1,0 +1,4 @@
+-- This migration had to be generated empty with --create-only command and populated manually, because it's content cannot be expressed in Prisma schema
+
+-- Enable pg_trgm extension, for substring and fuzzy matching of strings
+CREATE EXTENSION pg_trgm;

--- a/prisma/migrations/20250715104114_generate_artist_tables_id_on_db_level/migration.sql
+++ b/prisma/migrations/20250715104114_generate_artist_tables_id_on_db_level/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "alternative_artist_names" ALTER COLUMN "name_id" SET DEFAULT gen_random_uuid();
+
+-- AlterTable
+ALTER TABLE "artists" ALTER COLUMN "artist_id" SET DEFAULT gen_random_uuid();

--- a/prisma/migrations/20250715124709_artist_name_related_gist_indices/migration.sql
+++ b/prisma/migrations/20250715124709_artist_name_related_gist_indices/migration.sql
@@ -1,0 +1,7 @@
+-- This migration had to be generated empty with --create-only command and populated manually, because it's content cannot be expressed in Prisma schema
+
+-- Gist index to use for case-insensitive substring and fuzzy search
+CREATE INDEX "artist_alt_name_trgm_gist_idx" ON "alternative_artist_names" USING GIST (lower("name") gist_trgm_ops);
+
+-- Gist index to use for case-insensitive substring and fuzzy search
+CREATE INDEX "artist_name_trgm_gist_idx" ON "artists" USING GIST (lower("name") gist_trgm_ops);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ datasource db {
 }
 
 model Artist {
-  id                String                  @id @default(uuid()) @map("artist_id") @db.Uuid
+  id                String                  @id @default(dbgenerated("gen_random_uuid()")) @map("artist_id") @db.Uuid
   name              String
   nameForSorting    String?                 @map("name_for_sorting")
   parentArtists     ParentArtist[]          @relation("ParentArtist")
@@ -22,16 +22,18 @@ model Artist {
   type              ArtistType
 
   @@index([name])
+
   @@map("artists")
 }
 
 model AlternativeArtistName {
-  id       String @id @default(uuid()) @map("name_id") @db.Uuid
+  id       String @id @default(dbgenerated("gen_random_uuid()")) @map("name_id") @db.Uuid
   name     String
   artist   Artist @relation(fields: [artistId], references: [id])
   artistId String @map("artist_id") @db.Uuid
 
   @@index([name])
+
   @@map("alternative_artist_names")
 }
 


### PR DESCRIPTION
...on artists name columns, for efficient substring and fuzzy match

Also fixed definition of default for id columns - original definition uuid() meant the default when new elements are inserted via Prisma ORM, not by database in any case