### PR TITLE
Add labels DB query and entry-window IPC for fetchLabels

### DIFF
--- a/appConstants/ipcEvents.ts
+++ b/appConstants/ipcEvents.ts
@@ -5,6 +5,7 @@ export const GET_ENTRY_BY_ID = "get-entry-by-id";
 export const GET_ENTRY_RELEASES = "get-entry-releases";
 export const GET_RELEASE_BY_ID = "get-release-by-id";
 export const FETCH_RELEASE_FORMATS = "fetch-release-formats";
+export const FETCH_LABELS = "fetch-labels";
 export const SEARCH_ARTIST_ENTRIES = "search-artist-entries";
 
 export const OPEN_ARTIST_WINDOW = "open-new-artist-window";

--- a/src/app/windows/entry/api.ts
+++ b/src/app/windows/entry/api.ts
@@ -1,8 +1,10 @@
 import type { GetEntryById } from "@/types/entries";
 import type { ReleasesFormatListItem } from "@/types/formats";
+import type { LabelListItem } from "@/types/labels";
 import type { GetEntryReleases, GetReleaseById } from "@/types/releases";
 
 export type API = {
+  fetchLabels: () => Promise<LabelListItem[]>;
   fetchReleasesFormats: () => Promise<ReleasesFormatListItem[]>;
   getEntryById: GetEntryById;
   getEntryReleases: GetEntryReleases;

--- a/src/app/windows/entry/preload.ts
+++ b/src/app/windows/entry/preload.ts
@@ -3,6 +3,7 @@ import { contextBridge, ipcRenderer } from "electron";
 import type { API } from "./api";
 
 import {
+  FETCH_LABELS,
   FETCH_RELEASE_FORMATS,
   GET_ENTRY_BY_ID,
   GET_ENTRY_RELEASES,
@@ -10,6 +11,7 @@ import {
 } from "@/appConstants/ipcEvents";
 
 const api = {
+  fetchLabels: () => ipcRenderer.invoke(FETCH_LABELS),
   fetchReleasesFormats: () => ipcRenderer.invoke(FETCH_RELEASE_FORMATS),
   getEntryById: (entryId: string) =>
     ipcRenderer.invoke(GET_ENTRY_BY_ID, entryId),

--- a/src/db/labels/index.ts
+++ b/src/db/labels/index.ts
@@ -1,0 +1,10 @@
+import client from "../client/kysely";
+
+import type { LabelListItem } from "@/types/labels";
+
+export const fetchLabels = (): Promise<LabelListItem[]> =>
+  client
+    .selectFrom("labels")
+    .select(["labelId", "name"])
+    .orderBy("name")
+    .execute();

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import {
   GET_ENTRY_RELEASES,
   GET_RELEASE_BY_ID,
   FETCH_RELEASE_FORMATS,
+  FETCH_LABELS,
   OPEN_ARTIST_WINDOW,
   OPEN_ENTRY_WINDOW,
   QUERY_ARTIST,
@@ -24,6 +25,7 @@ import {
 import { fetchArtists, getArtistById, queryArtist } from "@/db/artists";
 import { getEntryById, searchArtistEntries } from "@/db/entries";
 import { fetchReleasesFormats } from "@/db/formats";
+import { fetchLabels } from "@/db/labels";
 import { getEntryReleases, getReleaseById } from "@/db/releases";
 import type { FetchArtistsParams } from "@/types/artists";
 import type { SearchArtistEntriesParams } from "@/types/entries";
@@ -55,6 +57,7 @@ await app.whenReady().then(async () => {
     getReleaseById(releaseId),
   );
   ipcMain.handle(FETCH_RELEASE_FORMATS, () => fetchReleasesFormats());
+  ipcMain.handle(FETCH_LABELS, () => fetchLabels());
   ipcMain.handle(
     SEARCH_ARTIST_ENTRIES,
     (_, params: SearchArtistEntriesParams) => searchArtistEntries(params),

--- a/src/types/labels.ts
+++ b/src/types/labels.ts
@@ -1,0 +1,4 @@
+export type LabelListItem = {
+  labelId: string;
+  name: string;
+};


### PR DESCRIPTION
Introduce fetchLabels (ordered by name), LabelListItem type, FETCH_LABELS channel, main handler, and preload/API exposure mirroring release formats.

Made-with: Cursor