### PR TITLE
add discogsUrl field to add release form

### DIFF
--- a/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseForm.tsx
+++ b/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseForm.tsx
@@ -54,6 +54,9 @@ const RELEASE_DATE_FIELD_ERROR_ID = "add-release-date-error";
 const RELEASE_VERSION_FIELD_ERROR_ID = "add-release-version-error";
 const RELEASE_VERSION_FIELD_NOTIFICATIONS_ID =
   "add-release-version-notifications";
+const DISCOGS_URL_FIELD_ERROR_ID = "add-release-discogs-url-error";
+const DISCOGS_URL_FIELD_NOTIFICATIONS_ID =
+  "add-release-discogs-url-notifications";
 
 const AddReleaseForm: FC<AddReleaseFormProps> = ({
   entry,
@@ -104,9 +107,9 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
 
   // on focus we attempt to remove errors related to the field that is being focused
   const onFocus = (key: AddReleaseFormInputFieldKey) => {
-    if (key === "releaseVersion") {
-      setField("releaseVersion", (prev) => ({
-        ...prev.releaseVersion,
+    if (key === "releaseVersion" || key === "discogsUrl") {
+      setField(key, (prev) => ({
+        ...prev[key],
         notifications: [],
       }));
     }
@@ -409,6 +412,7 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
 
     const validationResults = {
       releaseVersion: validateField("releaseVersion"),
+      discogsUrl: validateField("discogsUrl"),
       releaseDate: validateField("releaseDate"),
       countries: validateField("countries"),
       formats: validateField("formats"),
@@ -432,6 +436,7 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
 
     const {
       releaseVersion: { value: releaseVersion },
+      discogsUrl: { value: discogsUrl },
       releaseDate: { value: releaseDate },
       countries: { value: countries },
       formats: { value: formats },
@@ -442,6 +447,7 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
 
     console.info({
       releaseVersion,
+      discogsUrl,
       releaseDate,
       countries,
       formats,
@@ -453,10 +459,14 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
 
   const releaseVersionErrors = fieldErrors.releaseVersion;
   const releaseVersionNotifications = form.releaseVersion.notifications;
+  const discogsUrlErrors = fieldErrors.discogsUrl;
+  const discogsUrlNotifications = form.discogsUrl.notifications;
   const matrixRunoutErrors = fieldErrors.matrixRunout;
   const releaseDateErrors = fieldErrors.releaseDate;
   const hasReleaseVersionErrors = releaseVersionErrors.length > 0;
   const hasReleaseVersionNotifications = releaseVersionNotifications.length > 0;
+  const hasDiscogsUrlErrors = discogsUrlErrors.length > 0;
+  const hasDiscogsUrlNotifications = discogsUrlNotifications.length > 0;
   const hasReleaseDateErrors = releaseDateErrors.length > 0;
 
   const releaseVersionDescribedByIds = [
@@ -464,6 +474,13 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
     hasReleaseVersionNotifications
       ? RELEASE_VERSION_FIELD_NOTIFICATIONS_ID
       : null,
+  ]
+    .filter((id): id is string => id !== null)
+    .join(" ");
+
+  const discogsUrlDescribedByIds = [
+    hasDiscogsUrlErrors ? DISCOGS_URL_FIELD_ERROR_ID : null,
+    hasDiscogsUrlNotifications ? DISCOGS_URL_FIELD_NOTIFICATIONS_ID : null,
   ]
     .filter((id): id is string => id !== null)
     .join(" ");
@@ -521,6 +538,38 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
           <FormFieldErrorMessages
             id={RELEASE_DATE_FIELD_ERROR_ID}
             messages={releaseDateErrors}
+          />
+        </div>
+
+        <hr
+          className={`${styles.sectionDivider} ${styles.sectionDividerMoreSpaceBefore}`}
+          aria-hidden
+        />
+
+        <div className={styles.field}>
+          <label className={styles.heading} htmlFor="add-release-discogs-url">
+            Discogs URL
+          </label>
+          <input
+            id="add-release-discogs-url"
+            className={styles.input}
+            type="url"
+            value={form.discogsUrl.value}
+            onChange={(e) => setFieldValue("discogsUrl", e.target.value)}
+            onFocus={() => onFocus("discogsUrl")}
+            onBlur={() => onBlur("discogsUrl")}
+            aria-invalid={hasDiscogsUrlErrors}
+            aria-describedby={discogsUrlDescribedByIds || undefined}
+            autoComplete="off"
+            placeholder="https://www.discogs.com/release/<id>-..."
+          />
+          <FormFieldErrorMessages
+            id={DISCOGS_URL_FIELD_ERROR_ID}
+            messages={discogsUrlErrors}
+          />
+          <FormFieldNotifications
+            id={DISCOGS_URL_FIELD_NOTIFICATIONS_ID}
+            messages={discogsUrlNotifications}
           />
         </div>
 

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/errorMessages.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/errorMessages.ts
@@ -48,6 +48,7 @@ export type AddReleaseFormCatNumbersErrors = Record<
 
 export type AddReleaseFormFieldErrors = {
   releaseVersion: AddReleaseFormFieldError[];
+  discogsUrl: AddReleaseFormFieldError[];
   releaseDate: AddReleaseFormFieldError[];
   countries: AddReleaseFormCountriesErrors;
   formats: AddReleaseFormFormatErrors;
@@ -64,6 +65,7 @@ export const emptyMutableCountriesSubsectionErrors =
 
 export const initialAddReleaseFormFieldErrors: AddReleaseFormFieldErrors = {
   releaseVersion: [],
+  discogsUrl: [],
   releaseDate: [],
   countries: {
     madeIn: emptyMutableCountriesSubsectionErrors(),
@@ -97,6 +99,7 @@ export type AddReleaseFormCountriesInputFieldKey = {
 
 export type AddReleaseFormInputFieldKey =
   | "releaseVersion"
+  | "discogsUrl"
   | "matrixRunout"
   | ReleaseDateFieldErrorSource
   | AddReleaseFormFormatInputFieldKey

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/formValues.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/formValues.ts
@@ -9,6 +9,7 @@ import type {
 import {
   validateReleaseDate,
   validateReleaseVersion,
+  validateDiscogsUrl,
   validateReleaseCountries,
   validateReleaseFormats,
   validateReleaseCatNumbers,
@@ -98,6 +99,7 @@ type FormField<T, U> = {
 
 export type AddReleaseFormDraft = {
   releaseVersion: FormField<string, AddReleaseFormFieldError[]>;
+  discogsUrl: FormField<string, AddReleaseFormFieldError[]>;
   releaseDate: FormField<
     GeneralizedDateFormInputValue,
     AddReleaseFormFieldError[]
@@ -112,7 +114,6 @@ export type AddReleaseFormDraft = {
     AddReleaseFormMatrixRunoutDraft,
     AddReleaseFormFieldError[]
   >;
-
   selectedTags: FormField<Record<string, string>, never>;
 };
 
@@ -124,6 +125,12 @@ export const initialAddReleaseFormDraftValue = (
     value: "",
     valid: true,
     validationFn: validateReleaseVersion,
+    notifications: [],
+  },
+  discogsUrl: {
+    value: "",
+    valid: true,
+    validationFn: validateDiscogsUrl,
     notifications: [],
   },
   releaseDate: {

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/discogsUrl.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/discogsUrl.ts
@@ -39,5 +39,5 @@ const discogsUrlSchema = z
   .trim()
   .refine(
     (value) => value === "" || discogsUrlPattern.test(value),
-    "Discogs URL must start with https://www.discogs.com/release/<id>-",
+    "Discogs URL must be of the form https://www.discogs.com/release/<numerical id>-<arbitrary text>",
   );

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/discogsUrl.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/discogsUrl.ts
@@ -1,0 +1,43 @@
+import z from "zod";
+
+import type { FormFieldValidationResult } from "./types";
+
+import type { AddReleaseFormFieldError } from "../errorMessages";
+
+export const validateDiscogsUrl = (
+  value: string,
+): FormFieldValidationResult<string, AddReleaseFormFieldError[]> => {
+  const validationResult = discogsUrlSchema.safeParse(value);
+
+  if (!validationResult.success) {
+    return {
+      valid: false,
+      value,
+      errorMessages: validationResult.error.issues.map(({ message }) => ({
+        message,
+      })),
+    };
+  }
+
+  const validatedValue = validationResult.data;
+
+  return {
+    valid: true,
+    value: validatedValue,
+    notifications:
+      validatedValue === value
+        ? undefined
+        : [{ notification: "Note: value has been trimmed" }],
+  };
+};
+
+// See documentation/database/tables/musical_releases_table.md
+const discogsUrlPattern = /^https:\/\/www\.discogs\.com\/release\/\d+-./;
+
+const discogsUrlSchema = z
+  .string()
+  .trim()
+  .refine(
+    (value) => value === "" || discogsUrlPattern.test(value),
+    "Discogs URL must start with https://www.discogs.com/release/<id>-",
+  );

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/index.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/index.ts
@@ -1,4 +1,5 @@
 export * from "./releaseVersion";
+export * from "./discogsUrl";
 export * from "./releaseDate";
 export * from "./countries";
 export * from "./formats";


### PR DESCRIPTION
Adds a new optional `discogsUrl` form field next to the release version / release date block, with a dedicated validator that trims the input and enforces the
`^https://www.discogs.com/release/<id>-` shape mandated by the musical_releases insert / update trigger.