### PR TITLE
Add Europe/UK shape for catalogue numbers in AddReleaseForm

### DIFF
--- a/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/AddReleaseCatalogueNumbersRow.module.css
+++ b/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/AddReleaseCatalogueNumbersRow.module.css
@@ -1,14 +1,63 @@
+.shapeToggle {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+}
+
+.shapeToggleLegend {
+  font-weight: 600;
+  font-size: 0.92em;
+  padding: 0;
+  margin: 0 0.25rem 0.35rem 0;
+}
+
+.shapeToggleOption {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.92em;
+  cursor: pointer;
+}
+
+/* Each section (Labels / Catalogue numbers / "in UK" / "in Europe") stacks
+ * vertically and spans the full row width. Within a section, the inputs flow
+ * left-to-right and wrap as needed, with the "+ Add another …" button trailing
+ * the last input.
+ */
 .rowColumns {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+.column {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: flex-start;
-  gap: 1rem 1.25rem;
+  gap: 0.5rem 0.75rem;
 }
 
-.column {
-  flex: 1 1 11rem;
-  min-width: 0;
+.columnHeading {
+  flex: 0 0 100%;
+  font-weight: 600;
+  font-size: 0.92em;
+  margin: 0 0 0.25rem;
+}
+
+.inputValueBlock {
+  flex: 0 0 100%;
+}
+
+.rowActions {
+  flex: 0 0 100%;
 }
 
 .rowBlock {
@@ -24,23 +73,6 @@
   border: none;
   border-top: 1px solid rgba(0, 0, 0, 0.12);
   margin: 1rem 0 0.75rem;
-}
-
-.inputValueBlock {
-  margin-bottom: 0.35rem;
-}
-
-.label {
-  font-weight: 600;
-  font-size: 0.92em;
-}
-
-.segment {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  min-width: 0;
-  width: 100%;
 }
 
 .fieldErrorSlot {
@@ -106,14 +138,6 @@
 .removeCross:focus-visible {
   outline: 2px solid #1a5fb4;
   outline-offset: 1px;
-}
-
-.rowActions {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.35rem;
-  margin-top: 0.35rem;
 }
 
 .addAnotherInputValue {

--- a/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/AddReleaseCatalogueNumbersRow.module.css.d.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/AddReleaseCatalogueNumbersRow.module.css.d.ts
@@ -3,12 +3,12 @@
 interface CssExports {
   'addAnotherInputValue': string;
   'column': string;
+  'columnHeading': string;
   'controlWithRemove': string;
   'divider': string;
   'fieldErrorSlot': string;
   'input': string;
   'inputValueBlock': string;
-  'label': string;
   'removeCross': string;
   'removeCrossInputValue': string;
   'removeRow': string;
@@ -18,7 +18,9 @@ interface CssExports {
   'rowBlockFirst': string;
   'rowColumns': string;
   'rowErrorSlot': string;
-  'segment': string;
+  'shapeToggle': string;
+  'shapeToggleLegend': string;
+  'shapeToggleOption': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/CatalogueNumberInputColumn/index.tsx
+++ b/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/CatalogueNumberInputColumn/index.tsx
@@ -1,0 +1,118 @@
+import type { FC } from "react";
+
+import styles from "../AddReleaseCatalogueNumbersRow.module.css";
+
+import FormFieldErrorMessages from "@/app/components/FormFieldErrorMessages";
+
+export type CatalogueNumberInputColumnProps = {
+  /** Visible heading shown once at the top of the column (e.g. "Catalogue
+   * numbers", "Catalogue numbers in Europe"). */
+  columnHeading: string;
+
+  /** Singular accessible label per input ("Catalogue number",
+   * "Catalogue number in Europe"). Each input gets `${label} ${index + 1}` as
+   * its aria-label, since the visible heading is shared by the whole column. */
+  inputAriaLabel: string;
+
+  /** Prefix used to build stable DOM ids: `${idPrefix}-${rowId}-${inputId}` for
+   * the input and `${errorIdPrefix}-${rowId}-${inputId}` for the error
+   * region. */
+  idPrefix: string;
+  errorIdPrefix: string;
+  rowId: string;
+  inputValues: { id: string; value: string }[];
+  errorMessagesByInputId: Record<string, Set<string>> | undefined;
+  canRemoveAnyInput: boolean;
+  addButtonLabel: string;
+  removeInputAriaLabel: string;
+  onSetValue: (inputValueId: string, value: string) => void;
+  onAddInput: () => void;
+  onRemoveInput: (inputValueId: string) => void;
+  onInputFocus: (inputValueId: string) => void;
+  onInputBlur: () => void;
+};
+
+const CatalogueNumberInputColumn: FC<CatalogueNumberInputColumnProps> = ({
+  columnHeading,
+  inputAriaLabel,
+  idPrefix,
+  errorIdPrefix,
+  rowId,
+  inputValues,
+  errorMessagesByInputId,
+  canRemoveAnyInput,
+  addButtonLabel,
+  removeInputAriaLabel,
+  onSetValue,
+  onAddInput,
+  onRemoveInput,
+  onInputFocus,
+  onInputBlur,
+}) => (
+  <div className={styles.column}>
+    <div className={styles.columnHeading}>{columnHeading}</div>
+    {inputValues.map((inputValue, index) => {
+      const errorMessages = errorSetToMessages(
+        errorMessagesByInputId?.[inputValue.id],
+      );
+      const inputId = `${idPrefix}-${rowId}-${inputValue.id}`;
+      const errorId = `${errorIdPrefix}-${rowId}-${inputValue.id}`;
+      const hasErrors = errorMessages != null && errorMessages.length > 0;
+
+      return (
+        <div key={inputValue.id} className={styles.inputValueBlock}>
+          <div className={styles.controlWithRemove}>
+            <input
+              id={inputId}
+              className={styles.input}
+              type="text"
+              value={inputValue.value}
+              aria-label={`${inputAriaLabel} ${index + 1}`}
+              aria-invalid={hasErrors}
+              aria-describedby={hasErrors ? errorId : undefined}
+              onChange={(e) => onSetValue(inputValue.id, e.target.value)}
+              onFocus={() => onInputFocus(inputValue.id)}
+              onBlur={onInputBlur}
+              autoComplete="off"
+            />
+            <div
+              className={styles.removeCrossInputValue}
+              aria-hidden={canRemoveAnyInput ? undefined : true}
+            >
+              {canRemoveAnyInput && (
+                <button
+                  type="button"
+                  className={styles.removeCross}
+                  aria-label={removeInputAriaLabel}
+                  title={removeInputAriaLabel}
+                  onClick={() => onRemoveInput(inputValue.id)}
+                >
+                  <span aria-hidden="true">❌</span>
+                </button>
+              )}
+            </div>
+          </div>
+          {hasErrors && (
+            <div className={styles.fieldErrorSlot}>
+              <FormFieldErrorMessages id={errorId} messages={errorMessages} />
+            </div>
+          )}
+        </div>
+      );
+    })}
+    <div className={styles.rowActions}>
+      <button
+        type="button"
+        className={styles.addAnotherInputValue}
+        onClick={onAddInput}
+      >
+        {addButtonLabel}
+      </button>
+    </div>
+  </div>
+);
+
+export default CatalogueNumberInputColumn;
+
+const errorSetToMessages = (set?: Set<string>) =>
+  set && set.size > 0 ? Array.from(set, (message) => ({ message })) : null;

--- a/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/index.tsx
+++ b/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/AddReleaseCatalogueNumbersRow/index.tsx
@@ -1,13 +1,17 @@
 import type { FC } from "react";
 
 import styles from "./AddReleaseCatalogueNumbersRow.module.css";
+import CatalogueNumberInputColumn from "./CatalogueNumberInputColumn";
 
 import type {
   AddReleaseFormCatalogueNumberRowErrors,
   AddReleaseFormCatalogueNumbersInputFieldKey,
   CatalogueNumbersInputField,
 } from "../../addReleaseFormUtils/errorMessages";
-import type { CatalogueNumberRowState } from "../../addReleaseFormUtils/formValues";
+import type {
+  CatalogueNumberRowShape,
+  CatalogueNumberRowState,
+} from "../../addReleaseFormUtils/formValues";
 
 import FormFieldErrorMessages from "@/app/components/FormFieldErrorMessages";
 import type { LabelListItem } from "@/types/labels";
@@ -17,14 +21,20 @@ export type AddReleaseCatalogueNumbersRowProps = {
   rowIndex: number;
   showDivider: boolean;
   labels: LabelListItem[];
-  catNumberSectionValuesAreInvalid: boolean;
   rowErrors?: AddReleaseFormCatalogueNumberRowErrors | undefined;
+  onSetRowShape: (shape: CatalogueNumberRowShape) => void;
   onAddNewLabelInput: () => void;
   onRemoveLabelInput: (inputValueId: string) => void;
   onSetLabelName: (inputValueId: string, name: string) => void;
   onAddNewCatalogueNumberInput: () => void;
   onRemoveCatalogueNumberInput: (inputValueId: string) => void;
   onSetCatalogueNumber: (inputValueId: string, value: string) => void;
+  onAddNewEuropeCatalogueNumberInput: () => void;
+  onRemoveEuropeCatalogueNumberInput: (inputValueId: string) => void;
+  onSetEuropeCatalogueNumber: (inputValueId: string, value: string) => void;
+  onAddNewUkCatalogueNumberInput: () => void;
+  onRemoveUkCatalogueNumberInput: (inputValueId: string) => void;
+  onSetUkCatalogueNumber: (inputValueId: string, value: string) => void;
   onRemoveRow: () => void;
   onFieldFocus: (key: AddReleaseFormCatalogueNumbersInputFieldKey) => void;
   onBlurRowColumn: (fieldType: CatalogueNumbersInputField) => void;
@@ -35,14 +45,20 @@ const AddReleaseCatalogueNumbersRow: FC<AddReleaseCatalogueNumbersRowProps> = ({
   rowIndex,
   showDivider,
   labels,
-  catNumberSectionValuesAreInvalid,
   rowErrors,
+  onSetRowShape,
   onAddNewLabelInput,
   onRemoveLabelInput,
   onSetLabelName,
   onAddNewCatalogueNumberInput,
   onRemoveCatalogueNumberInput,
   onSetCatalogueNumber,
+  onAddNewEuropeCatalogueNumberInput,
+  onRemoveEuropeCatalogueNumberInput,
+  onSetEuropeCatalogueNumber,
+  onAddNewUkCatalogueNumberInput,
+  onRemoveUkCatalogueNumberInput,
+  onSetUkCatalogueNumber,
   onRemoveRow,
   onFieldFocus,
   onBlurRowColumn,
@@ -52,11 +68,30 @@ const AddReleaseCatalogueNumbersRow: FC<AddReleaseCatalogueNumbersRowProps> = ({
       ? `${styles.rowBlock} ${styles.rowBlockFirst}`
       : styles.rowBlock;
 
-  const canRemoveAnyInput =
-    row.labelInputValues.length + row.catalogueNumberInputValues.length > 1;
+  const catNumberInputsCount =
+    row.shape === "flat"
+      ? row.catalogueNumberInputValues.length
+      : row.europeCatalogueNumberInputValues.length +
+        row.ukCatalogueNumberInputValues.length;
+
+  const totalInputsInRow = row.labelInputValues.length + catNumberInputsCount;
+
+  // Per-column "can remove an input" rules. Flat shape only needs to keep at
+  // least one input in the row overall. europeUk shape additionally requires
+  // each region to keep at least one input slot — the DB schema forbids an
+  // empty region, so we never let the UI reach that state.
+  const canRemoveLabelInput =
+    row.shape === "flat" ? totalInputsInRow > 1 : true;
+  const canRemoveFlatCatNumberInput = totalInputsInRow > 1;
+  const canRemoveEuropeCatNumberInput =
+    row.shape === "europeUk" && row.europeCatalogueNumberInputValues.length > 1;
+  const canRemoveUkCatNumberInput =
+    row.shape === "europeUk" && row.ukCatalogueNumberInputValues.length > 1;
 
   const rowCommonErrorId = `add-release-cat-row-error-${row.id}`;
   const rowCommonMessages = errorSetToMessages(rowErrors?.rowErrorMessages);
+
+  const shapeToggleName = `add-release-cat-row-shape-${row.id}`;
 
   return (
     <>
@@ -71,7 +106,8 @@ const AddReleaseCatalogueNumbersRow: FC<AddReleaseCatalogueNumbersRowProps> = ({
         >
           <div className={styles.rowColumns}>
             <div className={styles.column}>
-              {row.labelInputValues.map((inputValue) => {
+              <div className={styles.columnHeading}>Labels</div>
+              {row.labelInputValues.map((inputValue, labelIndex) => {
                 const labelErrorMessages = errorSetToMessages(
                   rowErrors?.labelInputErrorMessages[inputValue.id],
                 );
@@ -81,168 +117,180 @@ const AddReleaseCatalogueNumbersRow: FC<AddReleaseCatalogueNumbersRowProps> = ({
 
                 return (
                   <div key={inputValue.id} className={styles.inputValueBlock}>
-                    <div className={styles.segment}>
-                      <label
-                        className={styles.label}
-                        htmlFor={`add-release-cat-label-${row.id}-${inputValue.id}`}
+                    <div className={styles.controlWithRemove}>
+                      <select
+                        id={`add-release-cat-label-${row.id}-${inputValue.id}`}
+                        className={styles.input}
+                        value={inputValue.name}
+                        aria-label={`Label ${labelIndex + 1}`}
+                        aria-invalid={hasLabelErrors}
+                        aria-describedby={
+                          hasLabelErrors ? labelErrorId : undefined
+                        }
+                        onChange={(e) =>
+                          onSetLabelName(inputValue.id, e.target.value)
+                        }
+                        onFocus={() =>
+                          onFieldFocus({
+                            catNumberRowId: row.id,
+                            field: "label",
+                            inputValueId: inputValue.id,
+                          })
+                        }
+                        onBlur={() => onBlurRowColumn("label")}
                       >
-                        Label
-                      </label>
-                      <div className={styles.controlWithRemove}>
-                        <select
-                          id={`add-release-cat-label-${row.id}-${inputValue.id}`}
-                          className={styles.input}
-                          value={inputValue.name}
-                          aria-invalid={hasLabelErrors}
-                          aria-describedby={
-                            hasLabelErrors ? labelErrorId : undefined
-                          }
-                          onChange={(e) =>
-                            onSetLabelName(inputValue.id, e.target.value)
-                          }
-                          onFocus={() =>
-                            onFieldFocus({
-                              catNumberRowId: row.id,
-                              field: "label",
-                              inputValueId: inputValue.id,
-                            })
-                          }
-                          onBlur={() => onBlurRowColumn("label")}
-                        >
-                          <option value="" />
-                          {labels.map((label) => (
-                            <option key={label.labelId} value={label.name}>
-                              {label.name}
-                            </option>
-                          ))}
-                        </select>
-                        <div
-                          className={styles.removeCrossInputValue}
-                          aria-hidden={canRemoveAnyInput ? undefined : true}
-                        >
-                          {canRemoveAnyInput && (
-                            <button
-                              type="button"
-                              className={styles.removeCross}
-                              aria-label="Remove label"
-                              title="Remove label"
-                              onClick={() => onRemoveLabelInput(inputValue.id)}
-                            >
-                              <span aria-hidden="true">❌</span>
-                            </button>
-                          )}
-                        </div>
+                        <option value="" />
+                        {labels.map((label) => (
+                          <option key={label.labelId} value={label.name}>
+                            {label.name}
+                          </option>
+                        ))}
+                      </select>
+                      <div
+                        className={styles.removeCrossInputValue}
+                        aria-hidden={canRemoveLabelInput ? undefined : true}
+                      >
+                        {canRemoveLabelInput && (
+                          <button
+                            type="button"
+                            className={styles.removeCross}
+                            aria-label="Remove label"
+                            title="Remove label"
+                            onClick={() => onRemoveLabelInput(inputValue.id)}
+                          >
+                            <span aria-hidden="true">❌</span>
+                          </button>
+                        )}
                       </div>
-                      {hasLabelErrors && (
-                        <div className={styles.fieldErrorSlot}>
-                          <FormFieldErrorMessages
-                            id={labelErrorId}
-                            messages={labelErrorMessages}
-                          />
-                        </div>
-                      )}
                     </div>
-                  </div>
-                );
-              })}
-              {!catNumberSectionValuesAreInvalid && (
-                <div className={styles.rowActions}>
-                  <button
-                    type="button"
-                    className={styles.addAnotherInputValue}
-                    onClick={onAddNewLabelInput}
-                  >
-                    + Add another label
-                  </button>
-                </div>
-              )}
-            </div>
-
-            <div className={styles.column}>
-              {row.catalogueNumberInputValues.map((inputValue) => {
-                const catNumberErrorMessages = errorSetToMessages(
-                  rowErrors?.catNumberInputErrorMessages[inputValue.id],
-                );
-                const catNumberErrorId = `add-release-cat-number-error-${row.id}-${inputValue.id}`;
-                const hasCatNumberErrors =
-                  catNumberErrorMessages != null &&
-                  catNumberErrorMessages.length > 0;
-
-                return (
-                  <div key={inputValue.id} className={styles.inputValueBlock}>
-                    <div className={styles.segment}>
-                      <label
-                        className={styles.label}
-                        htmlFor={`add-release-cat-number-${row.id}-${inputValue.id}`}
-                      >
-                        Catalogue number
-                      </label>
-                      <div className={styles.controlWithRemove}>
-                        <input
-                          id={`add-release-cat-number-${row.id}-${inputValue.id}`}
-                          className={styles.input}
-                          type="text"
-                          value={inputValue.value}
-                          aria-invalid={hasCatNumberErrors}
-                          aria-describedby={
-                            hasCatNumberErrors ? catNumberErrorId : undefined
-                          }
-                          onChange={(e) =>
-                            onSetCatalogueNumber(inputValue.id, e.target.value)
-                          }
-                          onFocus={() =>
-                            onFieldFocus({
-                              catNumberRowId: row.id,
-                              field: "catNumber",
-                              inputValueId: inputValue.id,
-                            })
-                          }
-                          onBlur={() => onBlurRowColumn("catNumber")}
-                          autoComplete="off"
+                    {hasLabelErrors && (
+                      <div className={styles.fieldErrorSlot}>
+                        <FormFieldErrorMessages
+                          id={labelErrorId}
+                          messages={labelErrorMessages}
                         />
-                        <div
-                          className={styles.removeCrossInputValue}
-                          aria-hidden={canRemoveAnyInput ? undefined : true}
-                        >
-                          {canRemoveAnyInput && (
-                            <button
-                              type="button"
-                              className={styles.removeCross}
-                              aria-label="Remove catalogue number"
-                              title="Remove catalogue number"
-                              onClick={() =>
-                                onRemoveCatalogueNumberInput(inputValue.id)
-                              }
-                            >
-                              <span aria-hidden="true">❌</span>
-                            </button>
-                          )}
-                        </div>
                       </div>
-                      {hasCatNumberErrors && (
-                        <div className={styles.fieldErrorSlot}>
-                          <FormFieldErrorMessages
-                            id={catNumberErrorId}
-                            messages={catNumberErrorMessages}
-                          />
-                        </div>
-                      )}
-                    </div>
+                    )}
                   </div>
                 );
               })}
-              {!catNumberSectionValuesAreInvalid && (
-                <div className={styles.rowActions}>
-                  <button
-                    type="button"
-                    className={styles.addAnotherInputValue}
-                    onClick={onAddNewCatalogueNumberInput}
-                  >
-                    + Add another catalogue number
-                  </button>
-                </div>
-              )}
+              <div className={styles.rowActions}>
+                <button
+                  type="button"
+                  className={styles.addAnotherInputValue}
+                  onClick={onAddNewLabelInput}
+                >
+                  + Add another label
+                </button>
+              </div>
             </div>
+
+            <fieldset className={styles.shapeToggle}>
+              <legend className={styles.shapeToggleLegend}>
+                Catalogue numbers shape
+              </legend>
+              <label className={styles.shapeToggleOption}>
+                <input
+                  type="radio"
+                  name={shapeToggleName}
+                  value="flat"
+                  checked={row.shape === "flat"}
+                  onChange={() => onSetRowShape("flat")}
+                />
+                Flat list
+              </label>
+              <label className={styles.shapeToggleOption}>
+                <input
+                  type="radio"
+                  name={shapeToggleName}
+                  value="europeUk"
+                  checked={row.shape === "europeUk"}
+                  onChange={() => onSetRowShape("europeUk")}
+                />
+                Split by region (Europe / UK)
+              </label>
+            </fieldset>
+
+            {row.shape === "flat" && (
+              <CatalogueNumberInputColumn
+                columnHeading="Catalogue numbers"
+                inputAriaLabel="Catalogue number"
+                idPrefix="add-release-cat-number"
+                errorIdPrefix="add-release-cat-number-error"
+                rowId={row.id}
+                inputValues={row.catalogueNumberInputValues}
+                errorMessagesByInputId={rowErrors?.catNumberInputErrorMessages}
+                canRemoveAnyInput={canRemoveFlatCatNumberInput}
+                addButtonLabel="+ Add another catalogue number"
+                removeInputAriaLabel="Remove catalogue number"
+                onSetValue={onSetCatalogueNumber}
+                onAddInput={onAddNewCatalogueNumberInput}
+                onRemoveInput={onRemoveCatalogueNumberInput}
+                onInputFocus={(inputValueId) =>
+                  onFieldFocus({
+                    catNumberRowId: row.id,
+                    field: "catNumber",
+                    inputValueId,
+                  })
+                }
+                onInputBlur={() => onBlurRowColumn("catNumber")}
+              />
+            )}
+
+            {row.shape === "europeUk" && (
+              <>
+                <CatalogueNumberInputColumn
+                  columnHeading="Catalogue numbers in UK"
+                  inputAriaLabel="Catalogue number in UK"
+                  idPrefix="add-release-cat-uk"
+                  errorIdPrefix="add-release-cat-uk-error"
+                  rowId={row.id}
+                  inputValues={row.ukCatalogueNumberInputValues}
+                  errorMessagesByInputId={
+                    rowErrors?.ukCatNumberInputErrorMessages
+                  }
+                  canRemoveAnyInput={canRemoveUkCatNumberInput}
+                  addButtonLabel='+ Add another "in UK" value'
+                  removeInputAriaLabel='Remove "in UK" catalogue number'
+                  onSetValue={onSetUkCatalogueNumber}
+                  onAddInput={onAddNewUkCatalogueNumberInput}
+                  onRemoveInput={onRemoveUkCatalogueNumberInput}
+                  onInputFocus={(inputValueId) =>
+                    onFieldFocus({
+                      catNumberRowId: row.id,
+                      field: "ukCatNumber",
+                      inputValueId,
+                    })
+                  }
+                  onInputBlur={() => onBlurRowColumn("ukCatNumber")}
+                />
+                <CatalogueNumberInputColumn
+                  columnHeading="Catalogue numbers in Europe"
+                  inputAriaLabel="Catalogue number in Europe"
+                  idPrefix="add-release-cat-europe"
+                  errorIdPrefix="add-release-cat-europe-error"
+                  rowId={row.id}
+                  inputValues={row.europeCatalogueNumberInputValues}
+                  errorMessagesByInputId={
+                    rowErrors?.europeCatNumberInputErrorMessages
+                  }
+                  canRemoveAnyInput={canRemoveEuropeCatNumberInput}
+                  addButtonLabel='+ Add another "in Europe" value'
+                  removeInputAriaLabel='Remove "in Europe" catalogue number'
+                  onSetValue={onSetEuropeCatalogueNumber}
+                  onAddInput={onAddNewEuropeCatalogueNumberInput}
+                  onRemoveInput={onRemoveEuropeCatalogueNumberInput}
+                  onInputFocus={(inputValueId) =>
+                    onFieldFocus({
+                      catNumberRowId: row.id,
+                      field: "europeCatNumber",
+                      inputValueId,
+                    })
+                  }
+                  onInputBlur={() => onBlurRowColumn("europeCatNumber")}
+                />
+              </>
+            )}
           </div>
 
           {rowCommonMessages && rowCommonMessages.length > 0 && (

--- a/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/index.tsx
+++ b/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseCatalogueNumbersSection/index.tsx
@@ -4,7 +4,6 @@ import AddReleaseCatalogueNumbersRow from "./AddReleaseCatalogueNumbersRow";
 import styles from "./AddReleaseCatalogueNumbersSection.module.css";
 
 import {
-  type AddReleaseFormCatalogueNumberRowErrors,
   type AddReleaseFormCatalogueNumbersInputFieldKey,
   type AddReleaseFormFieldErrors,
   type CatalogueNumbersInputField,
@@ -12,7 +11,14 @@ import {
 import {
   emptyCatalogueNumberInputValue,
   emptyLabelInputValue,
+  toEuropeUkRow,
+  toFlatRow,
+  type CatalogueNumberInputValue,
+  type CatalogueNumberRowShape,
   type CatalogueNumberRowState,
+  type CatalogueNumberRowStateEuropeUk,
+  type CatalogueNumberRowStateFlat,
+  type LabelInputValue,
 } from "../addReleaseFormUtils/formValues";
 
 import type { LabelListItem } from "@/types/labels";
@@ -47,90 +53,113 @@ const AddReleaseCatalogueNumbersSection: FC<
   onFieldFocus,
   onBlurRowColumn,
 }) => {
-  const catNumberSectionValuesAreInvalid =
-    !catalogueNumberRowsAreFullyFilled(catalogueNumbers) ||
-    catalogueNumbersSectionHasAnyErrors(errors);
-
-  const addNewLabelInput = (rowId: string) => {
+  const updateRow = (
+    rowId: string,
+    update: (row: CatalogueNumberRowState) => CatalogueNumberRowState,
+  ) => {
     setCatalogueNumbers((prev) =>
-      prev.map((row) =>
-        row.id === rowId
-          ? {
-              ...row,
-              labelInputValues: [
-                ...row.labelInputValues,
-                emptyLabelInputValue(),
-              ],
-            }
-          : row,
-      ),
+      prev.map((row) => (row.id === rowId ? update(row) : row)),
     );
   };
 
-  const removeLabelInput = (rowId: string, inputValueId: string) => {
-    setCatalogueNumbers((prev) =>
-      prev.map((row) => {
-        if (row.id !== rowId) {
-          return row;
-        }
+  const setRowShape = (rowId: string, shape: CatalogueNumberRowShape) => {
+    updateRow(rowId, (row) =>
+      shape === "flat" ? toFlatRow(row) : toEuropeUkRow(row),
+    );
+  };
 
-        return {
-          ...row,
-          labelInputValues: row.labelInputValues.filter(
-            (inputValue) => inputValue.id !== inputValueId,
-          ),
-        };
-      }),
+  const updateLabelInputs = (
+    rowId: string,
+    transform: (inputs: LabelInputValue[]) => LabelInputValue[],
+  ) => {
+    updateRow(rowId, (row) => ({
+      ...row,
+      labelInputValues: transform(row.labelInputValues),
+    }));
+  };
+
+  const addNewLabelInput = (rowId: string) => {
+    updateLabelInputs(rowId, (inputs) => [...inputs, emptyLabelInputValue()]);
+  };
+
+  const removeLabelInput = (rowId: string, inputValueId: string) => {
+    updateLabelInputs(rowId, (inputs) =>
+      inputs.filter((inputValue) => inputValue.id !== inputValueId),
     );
   };
 
   const setLabelName = (rowId: string, inputValueId: string, name: string) => {
-    setCatalogueNumbers((prev) =>
-      prev.map((row) =>
-        row.id === rowId
-          ? {
-              ...row,
-              labelInputValues: row.labelInputValues.map((inputValue) =>
-                inputValue.id === inputValueId
-                  ? { ...inputValue, name }
-                  : inputValue,
-              ),
-            }
-          : row,
+    updateLabelInputs(rowId, (inputs) =>
+      inputs.map((inputValue) =>
+        inputValue.id === inputValueId ? { ...inputValue, name } : inputValue,
       ),
+    );
+  };
+
+  const updateFlatCatalogueNumberInputs = (
+    rowId: string,
+    transform: (
+      inputs: CatalogueNumberInputValue[],
+    ) => CatalogueNumberInputValue[],
+  ) => {
+    updateRow(rowId, (row) =>
+      row.shape === "flat"
+        ? ({
+            ...row,
+            catalogueNumberInputValues: transform(
+              row.catalogueNumberInputValues,
+            ),
+          } satisfies CatalogueNumberRowStateFlat)
+        : row,
+    );
+  };
+
+  const updateEuropeCatalogueNumberInputs = (
+    rowId: string,
+    transform: (
+      inputs: CatalogueNumberInputValue[],
+    ) => CatalogueNumberInputValue[],
+  ) => {
+    updateRow(rowId, (row) =>
+      row.shape === "europeUk"
+        ? ({
+            ...row,
+            europeCatalogueNumberInputValues: transform(
+              row.europeCatalogueNumberInputValues,
+            ),
+          } satisfies CatalogueNumberRowStateEuropeUk)
+        : row,
+    );
+  };
+
+  const updateUkCatalogueNumberInputs = (
+    rowId: string,
+    transform: (
+      inputs: CatalogueNumberInputValue[],
+    ) => CatalogueNumberInputValue[],
+  ) => {
+    updateRow(rowId, (row) =>
+      row.shape === "europeUk"
+        ? ({
+            ...row,
+            ukCatalogueNumberInputValues: transform(
+              row.ukCatalogueNumberInputValues,
+            ),
+          } satisfies CatalogueNumberRowStateEuropeUk)
+        : row,
     );
   };
 
   const addNewCatalogueNumberInput = (rowId: string) => {
-    setCatalogueNumbers((prev) =>
-      prev.map((row) =>
-        row.id === rowId
-          ? {
-              ...row,
-              catalogueNumberInputValues: [
-                ...row.catalogueNumberInputValues,
-                emptyCatalogueNumberInputValue(),
-              ],
-            }
-          : row,
-      ),
-    );
+    updateFlatCatalogueNumberInputs(rowId, (inputs) => [
+      ...inputs,
+      emptyCatalogueNumberInputValue(),
+    ]);
   };
 
   const removeCatalogueNumberInput = (rowId: string, inputValueId: string) => {
-    setCatalogueNumbers((prev) =>
-      prev.map((row) => {
-        if (row.id !== rowId) {
-          return row;
-        }
-
-        return {
-          ...row,
-          catalogueNumberInputValues: row.catalogueNumberInputValues.filter(
-            (inputValue) => inputValue.id !== inputValueId,
-          ),
-        };
-      }),
+    updateFlatCatalogueNumberInputs(rowId, (inputs) =>
+      inputs.filter((inputValue) => inputValue.id !== inputValueId),
     );
   };
 
@@ -139,19 +168,65 @@ const AddReleaseCatalogueNumbersSection: FC<
     inputValueId: string,
     value: string,
   ) => {
-    setCatalogueNumbers((prev) =>
-      prev.map((row) =>
-        row.id === rowId
-          ? {
-              ...row,
-              catalogueNumberInputValues: row.catalogueNumberInputValues.map(
-                (inputValue) =>
-                  inputValue.id === inputValueId
-                    ? { ...inputValue, value }
-                    : inputValue,
-              ),
-            }
-          : row,
+    updateFlatCatalogueNumberInputs(rowId, (inputs) =>
+      inputs.map((inputValue) =>
+        inputValue.id === inputValueId ? { ...inputValue, value } : inputValue,
+      ),
+    );
+  };
+
+  const addNewEuropeCatalogueNumberInput = (rowId: string) => {
+    updateEuropeCatalogueNumberInputs(rowId, (inputs) => [
+      ...inputs,
+      emptyCatalogueNumberInputValue(),
+    ]);
+  };
+
+  const removeEuropeCatalogueNumberInput = (
+    rowId: string,
+    inputValueId: string,
+  ) => {
+    updateEuropeCatalogueNumberInputs(rowId, (inputs) =>
+      inputs.filter((inputValue) => inputValue.id !== inputValueId),
+    );
+  };
+
+  const setEuropeCatalogueNumber = (
+    rowId: string,
+    inputValueId: string,
+    value: string,
+  ) => {
+    updateEuropeCatalogueNumberInputs(rowId, (inputs) =>
+      inputs.map((inputValue) =>
+        inputValue.id === inputValueId ? { ...inputValue, value } : inputValue,
+      ),
+    );
+  };
+
+  const addNewUkCatalogueNumberInput = (rowId: string) => {
+    updateUkCatalogueNumberInputs(rowId, (inputs) => [
+      ...inputs,
+      emptyCatalogueNumberInputValue(),
+    ]);
+  };
+
+  const removeUkCatalogueNumberInput = (
+    rowId: string,
+    inputValueId: string,
+  ) => {
+    updateUkCatalogueNumberInputs(rowId, (inputs) =>
+      inputs.filter((inputValue) => inputValue.id !== inputValueId),
+    );
+  };
+
+  const setUkCatalogueNumber = (
+    rowId: string,
+    inputValueId: string,
+    value: string,
+  ) => {
+    updateUkCatalogueNumberInputs(rowId, (inputs) =>
+      inputs.map((inputValue) =>
+        inputValue.id === inputValueId ? { ...inputValue, value } : inputValue,
       ),
     );
   };
@@ -167,8 +242,8 @@ const AddReleaseCatalogueNumbersSection: FC<
             rowIndex={rowIndex}
             showDivider={rowIndex > 0}
             labels={labels}
-            catNumberSectionValuesAreInvalid={catNumberSectionValuesAreInvalid}
             rowErrors={errors?.[row.id]}
+            onSetRowShape={(shape) => setRowShape(row.id, shape)}
             onAddNewLabelInput={() => addNewLabelInput(row.id)}
             onSetLabelName={(inputValueId, name) =>
               setLabelName(row.id, inputValueId, name)
@@ -185,6 +260,24 @@ const AddReleaseCatalogueNumbersSection: FC<
             onSetCatalogueNumber={(inputValueId, value) =>
               setCatalogueNumber(row.id, inputValueId, value)
             }
+            onAddNewEuropeCatalogueNumberInput={() =>
+              addNewEuropeCatalogueNumberInput(row.id)
+            }
+            onRemoveEuropeCatalogueNumberInput={(inputValueId) =>
+              removeEuropeCatalogueNumberInput(row.id, inputValueId)
+            }
+            onSetEuropeCatalogueNumber={(inputValueId, value) =>
+              setEuropeCatalogueNumber(row.id, inputValueId, value)
+            }
+            onAddNewUkCatalogueNumberInput={() =>
+              addNewUkCatalogueNumberInput(row.id)
+            }
+            onRemoveUkCatalogueNumberInput={(inputValueId) =>
+              removeUkCatalogueNumberInput(row.id, inputValueId)
+            }
+            onSetUkCatalogueNumber={(inputValueId, value) =>
+              setUkCatalogueNumber(row.id, inputValueId, value)
+            }
             onRemoveRow={() => removeCatalogueNumbersRow(row.id)}
             onFieldFocus={onFieldFocus}
             onBlurRowColumn={(fieldType) => onBlurRowColumn(row.id, fieldType)}
@@ -192,65 +285,15 @@ const AddReleaseCatalogueNumbersSection: FC<
         </div>
       ))}
 
-      {!catNumberSectionValuesAreInvalid && (
-        <button
-          type="button"
-          className={styles.addAnotherRow}
-          onClick={addCatalogueNumbersRow}
-        >
-          + Add another catalogue row
-        </button>
-      )}
+      <button
+        type="button"
+        className={styles.addAnotherRow}
+        onClick={addCatalogueNumbersRow}
+      >
+        + Add another catalogue row
+      </button>
     </div>
   );
 };
 
 export default AddReleaseCatalogueNumbersSection;
-
-const catalogueNumberRowErrorsHasMessages = (
-  rowErrors: AddReleaseFormCatalogueNumberRowErrors | undefined,
-): boolean => {
-  if (!rowErrors) {
-    return false;
-  }
-
-  if (rowErrors.rowErrorMessages.size > 0) {
-    return true;
-  }
-
-  for (const messageSet of Object.values(rowErrors.labelInputErrorMessages)) {
-    if (messageSet.size > 0) {
-      return true;
-    }
-  }
-
-  for (const messageSet of Object.values(
-    rowErrors.catNumberInputErrorMessages,
-  )) {
-    if (messageSet.size > 0) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-const catalogueNumberRowsAreFullyFilled = (
-  rows: CatalogueNumberRowState[],
-): boolean =>
-  rows.every(
-    (row) =>
-      row.labelInputValues.every((label) => label.name.trim().length > 0) &&
-      row.catalogueNumberInputValues.every(
-        (cat) => cat.value.trim().length > 0,
-      ),
-  );
-
-const catalogueNumbersSectionHasAnyErrors = (
-  catalogueNumbersErrors:
-    | AddReleaseFormFieldErrors["catalogueNumbers"]
-    | undefined,
-): boolean =>
-  Object.values(catalogueNumbersErrors ?? {}).some(
-    catalogueNumberRowErrorsHasMessages,
-  );

--- a/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseForm.tsx
+++ b/src/app/windows/entry/Entry/AddReleaseForm/AddReleaseForm.tsx
@@ -5,6 +5,7 @@ import AddReleaseCountriesSection from "./AddReleaseCountriesSection";
 import styles from "./AddReleaseForm.module.css";
 import AddReleaseFormFormatsSection from "./AddReleaseFormFormatsSection";
 import {
+  catalogueNumbersInputBucketKeyFor,
   removeMadeInCountrySelectionRowFromFieldErrors,
   stripPrintedInFromCountriesFieldErrors,
   isCatalogueNumbersInputFieldKey,
@@ -145,10 +146,7 @@ const AddReleaseForm: FC<AddReleaseFormProps> = ({
           return prev;
         }
 
-        const errorKey =
-          field === "label"
-            ? "labelInputErrorMessages"
-            : "catNumberInputErrorMessages";
+        const errorKey = catalogueNumbersInputBucketKeyFor(field);
 
         const nextRowErrors = {
           ...rowErrors,

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/errorMessages.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/errorMessages.ts
@@ -23,6 +23,8 @@ type CountrySelectionRowId = string;
 export type AddReleaseFormCatalogueNumberRowErrors = {
   labelInputErrorMessages: Record<LabelInputId, Set<string>>;
   catNumberInputErrorMessages: Record<CatNumberInputId, Set<string>>;
+  europeCatNumberInputErrorMessages: Record<CatNumberInputId, Set<string>>;
+  ukCatNumberInputErrorMessages: Record<CatNumberInputId, Set<string>>;
   rowErrorMessages: Set<string>;
 };
 
@@ -87,7 +89,11 @@ export const initialAddReleaseFormFieldErrors: AddReleaseFormFieldErrors = {
   relationToQueen: undefined,
 };
 
-export type CatalogueNumbersInputField = "label" | "catNumber";
+export type CatalogueNumbersInputField =
+  | "label"
+  | "catNumber"
+  | "europeCatNumber"
+  | "ukCatNumber";
 
 export type AddReleaseFormFormatInputFieldKey = {
   formatRowId: string;
@@ -128,6 +134,30 @@ export const isFormatInputFieldKey = (key: AddReleaseFormInputFieldKey) =>
 export const isCatalogueNumbersInputFieldKey = (
   key: AddReleaseFormInputFieldKey,
 ) => typeof key === "object" && "catNumberRowId" in key;
+
+// Maps a per-input field key to the matching errors bucket on the row-errors
+// object. Used by focus-handlers to clear the right bucket without each call
+// site rebuilding the same conditional.
+export const catalogueNumbersInputBucketKeyFor = (
+  field: CatalogueNumbersInputField,
+): keyof Pick<
+  AddReleaseFormCatalogueNumberRowErrors,
+  | "labelInputErrorMessages"
+  | "catNumberInputErrorMessages"
+  | "europeCatNumberInputErrorMessages"
+  | "ukCatNumberInputErrorMessages"
+> => {
+  switch (field) {
+    case "label":
+      return "labelInputErrorMessages";
+    case "catNumber":
+      return "catNumberInputErrorMessages";
+    case "europeCatNumber":
+      return "europeCatNumberInputErrorMessages";
+    case "ukCatNumber":
+      return "ukCatNumberInputErrorMessages";
+  }
+};
 
 export const isCountriesInputFieldKey = (key: AddReleaseFormInputFieldKey) =>
   typeof key === "object" && "countriesSubsection" in key;

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/formValues.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/formValues.ts
@@ -55,10 +55,11 @@ export const defaultFormatInputRow = (): AddReleaseFormFormatInput => ({
   jukeboxHole: false,
 });
 
-export const emptyCatalogueNumberInputValue = () => ({
-  id: uuidv4(),
-  value: "",
-});
+export const emptyCatalogueNumberInputValue =
+  (): CatalogueNumberInputValue => ({
+    id: uuidv4(),
+    value: "",
+  });
 
 export type CountrySelectionInput = {
   id: string;
@@ -75,28 +76,85 @@ export const emptyCountrySelection = () => ({
   codeName: "",
 });
 
-export type CatalogueNumberRowState = {
+export type CatalogueNumberInputValue = { id: string; value: string };
+export type LabelInputValue = { id: string; name: string };
+
+export type CatalogueNumberRowShape = "flat" | "europeUk";
+
+export type CatalogueNumberRowStateFlat = {
   id: string;
-  labelInputValues: {
-    id: string;
-    name: string;
-  }[];
-  catalogueNumberInputValues: {
-    id: string;
-    value: string;
-  }[];
+  shape: "flat";
+  labelInputValues: LabelInputValue[];
+  catalogueNumberInputValues: CatalogueNumberInputValue[];
 };
 
-export const emptyLabelInputValue = () => ({
+export type CatalogueNumberRowStateEuropeUk = {
+  id: string;
+  shape: "europeUk";
+  labelInputValues: LabelInputValue[];
+  europeCatalogueNumberInputValues: CatalogueNumberInputValue[];
+  ukCatalogueNumberInputValues: CatalogueNumberInputValue[];
+};
+
+export type CatalogueNumberRowState =
+  | CatalogueNumberRowStateFlat
+  | CatalogueNumberRowStateEuropeUk;
+
+export const emptyLabelInputValue = (): LabelInputValue => ({
   id: uuidv4(),
   name: "",
 });
 
-export const defaultCatalogueNumberRow = (): CatalogueNumberRowState => ({
+export const defaultCatalogueNumberRow = (): CatalogueNumberRowStateFlat => ({
   id: uuidv4(),
+  shape: "flat",
   labelInputValues: [emptyLabelInputValue()],
-  catalogueNumberInputValues: [],
+  catalogueNumberInputValues: [emptyCatalogueNumberInputValue()],
 });
+
+// flat → europeUk: keep labels, move existing flat values into "in Europe",
+// seed "in UK" with one empty input so the user has somewhere to type. If the
+// flat row had no catalogue numbers at all, seed "in Europe" with an empty
+// input too — both regions are required in europeUk shape.
+export const toEuropeUkRow = (
+  row: CatalogueNumberRowState,
+): CatalogueNumberRowStateEuropeUk => {
+  if (row.shape === "europeUk") {
+    return row;
+  }
+
+  return {
+    id: row.id,
+    shape: "europeUk",
+    labelInputValues: row.labelInputValues,
+    europeCatalogueNumberInputValues:
+      row.catalogueNumberInputValues.length > 0
+        ? row.catalogueNumberInputValues
+        : [emptyCatalogueNumberInputValue()],
+    ukCatalogueNumberInputValues: [emptyCatalogueNumberInputValue()],
+  };
+};
+
+// europeUk → flat: keep labels, concatenate europe then UK values into a single
+// flat list, preserving ids so React keys and per-input errors survive the
+// transition.
+export const toFlatRow = (
+  row: CatalogueNumberRowState,
+): CatalogueNumberRowStateFlat => {
+  if (row.shape === "flat") {
+    return row;
+  }
+
+  return {
+    id: row.id,
+    shape: "flat",
+    labelInputValues: row.labelInputValues,
+    catalogueNumberInputValues: [
+      ...row.europeCatalogueNumberInputValues,
+      ...row.ukCatalogueNumberInputValues,
+    ],
+  };
+};
 
 export type AddReleaseFormMatrixRunoutDraft = {
   value: string;

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/toMusicalReleaseInsertValues.test.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/toMusicalReleaseInsertValues.test.ts
@@ -18,12 +18,34 @@ const catNumberRow = (
   catNumbers: string[],
 ): CatalogueNumberRowState => ({
   id: `${labels.join(",")}|${catNumbers.join(",")}`,
+  shape: "flat",
   labelInputValues: labels.map((name, index) => ({
     id: `label-${index}-${name}`,
     name,
   })),
   catalogueNumberInputValues: catNumbers.map((value, index) => ({
     id: `cat-${index}-${value}`,
+    value,
+  })),
+});
+
+const europeUkCatNumberRow = (
+  labels: string[],
+  europeCatNumbers: string[],
+  ukCatNumbers: string[],
+): CatalogueNumberRowState => ({
+  id: `${labels.join(",")}|EU:${europeCatNumbers.join(",")}|UK:${ukCatNumbers.join(",")}`,
+  shape: "europeUk",
+  labelInputValues: labels.map((name, index) => ({
+    id: `label-${index}-${name}`,
+    name,
+  })),
+  europeCatalogueNumberInputValues: europeCatNumbers.map((value, index) => ({
+    id: `eu-cat-${index}-${value}`,
+    value,
+  })),
+  ukCatalogueNumberInputValues: ukCatNumbers.map((value, index) => ({
+    id: `uk-cat-${index}-${value}`,
     value,
   })),
 });
@@ -340,6 +362,30 @@ describe("toReleaseCatNumbersJson", () => {
     ]);
   });
 
+  it("drops empty-string label inputs while keeping filled cat numbers", () => {
+    expect(toReleaseCatNumbersJson([catNumberRow([""], ["EMC 3001"])])).toEqual(
+      { cat_number: "EMC 3001" },
+    );
+  });
+
+  it("drops empty-string catalogue-number inputs while keeping filled labels", () => {
+    expect(toReleaseCatNumbersJson([catNumberRow(["EMI"], [""])])).toEqual({
+      label: "EMI",
+    });
+  });
+
+  it("trims values and skips entries that are whitespace-only", () => {
+    expect(
+      toReleaseCatNumbersJson([
+        catNumberRow(["  EMI  ", "   "], ["EMC 3001", " "]),
+      ]),
+    ).toEqual({ label: "EMI", cat_number: "EMC 3001" });
+  });
+
+  it("drops a row whose inputs are all empty strings", () => {
+    expect(toReleaseCatNumbersJson([catNumberRow([""], [""])])).toBeNull();
+  });
+
   it("preserves the order of labels and cat numbers within a row", () => {
     expect(
       toReleaseCatNumbersJson([catNumberRow(["C", "A", "B"], ["3", "1", "2"])]),
@@ -347,5 +393,100 @@ describe("toReleaseCatNumbersJson", () => {
       labels: ["C", "A", "B"],
       cat_numbers: ["3", "1", "2"],
     });
+  });
+
+  it("emits cat_numbers as an in-Europe/in-UK object for a single europeUk row with one value per side", () => {
+    expect(
+      toReleaseCatNumbersJson([
+        europeUkCatNumberRow(["EMI"], ["EMC 3001"], ["PCS 7066"]),
+      ]),
+    ).toEqual({
+      label: "EMI",
+      cat_numbers: { "in Europe": "EMC 3001", "in UK": "PCS 7066" },
+    });
+  });
+
+  it("uses arrays inside the in-Europe/in-UK object when a side has multiple values", () => {
+    expect(
+      toReleaseCatNumbersJson([
+        europeUkCatNumberRow(
+          ["EMI", "Parlophone"],
+          ["EMC 3001", "EMC 3002"],
+          ["PCS 7066", "PCS 7067"],
+        ),
+      ]),
+    ).toEqual({
+      labels: ["EMI", "Parlophone"],
+      cat_numbers: {
+        "in Europe": ["EMC 3001", "EMC 3002"],
+        "in UK": ["PCS 7066", "PCS 7067"],
+      },
+    });
+  });
+
+  it("mixes a single value on one side and multiple on the other inside the regions object", () => {
+    expect(
+      toReleaseCatNumbersJson([
+        europeUkCatNumberRow(["EMI"], ["EMC 3001"], ["PCS 7066", "PCS 7067"]),
+      ]),
+    ).toEqual({
+      label: "EMI",
+      cat_numbers: {
+        "in Europe": "EMC 3001",
+        "in UK": ["PCS 7066", "PCS 7067"],
+      },
+    });
+  });
+
+  it("omits the label side of a europeUk row when there are no labels", () => {
+    expect(
+      toReleaseCatNumbersJson([
+        europeUkCatNumberRow([], ["EMC 3001"], ["PCS 7066"]),
+      ]),
+    ).toEqual({
+      cat_numbers: { "in Europe": "EMC 3001", "in UK": "PCS 7066" },
+    });
+  });
+
+  it("supports mixing flat and europeUk rows in the same submission", () => {
+    expect(
+      toReleaseCatNumbersJson([
+        catNumberRow(["Capitol"], ["SMAS 11163"]),
+        europeUkCatNumberRow(["EMI"], ["EMC 3001"], ["PCS 7066"]),
+      ]),
+    ).toEqual([
+      { label: "Capitol", cat_number: "SMAS 11163" },
+      {
+        label: "EMI",
+        cat_numbers: { "in Europe": "EMC 3001", "in UK": "PCS 7066" },
+      },
+    ]);
+  });
+
+  it("preserves order across mixed flat and europeUk rows", () => {
+    expect(
+      toReleaseCatNumbersJson([
+        europeUkCatNumberRow(["EMI"], ["EMC 3001"], ["PCS 7066"]),
+        catNumberRow(["Capitol"], ["SMAS 11163"]),
+        europeUkCatNumberRow(
+          ["Parlophone"],
+          ["EMC 3002"],
+          ["PCS 7067", "PCS 7068"],
+        ),
+      ]),
+    ).toEqual([
+      {
+        label: "EMI",
+        cat_numbers: { "in Europe": "EMC 3001", "in UK": "PCS 7066" },
+      },
+      { label: "Capitol", cat_number: "SMAS 11163" },
+      {
+        label: "Parlophone",
+        cat_numbers: {
+          "in Europe": "EMC 3002",
+          "in UK": ["PCS 7067", "PCS 7068"],
+        },
+      },
+    ]);
   });
 });

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/toMusicalReleaseInsertValues.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/toMusicalReleaseInsertValues.ts
@@ -137,10 +137,16 @@ const toCodeNamesJson = (
 /**
  * Maps the form's catalogue-number rows to the jsonb shape: `null` when there
  * are no rows (or every row is empty), a single object for one row, or an
- * array for many. Each row picks `label` / `labels` and `cat_number` /
- * `cat_numbers` keys based on count, omitting either side when empty; rows
- * that would produce `{}` are dropped. The form does not produce the
- * Europe/UK or CD/slipcase nested variants.
+ * array for many. Each row picks `label` / `labels` keys based on count, and
+ * its cat-number side is shaped by `row.shape`:
+ *
+ * - "flat" rows pick `cat_number` / `cat_numbers: string | string[]`, omitting
+ *   the cat-number side entirely when no values are filled in;
+ * - "europeUk" rows always emit `cat_numbers: { "in Europe", "in UK" }` (both
+ *   sides guaranteed non-empty by the validator).
+ *
+ * Rows that would produce `{}` are dropped. The form does not produce the
+ * CD/slipcase nested variant.
  */
 export const toReleaseCatNumbersJson = (rows: AddReleaseFormCatNumbersInputs) =>
   singleOrArrayOrNull(
@@ -148,13 +154,59 @@ export const toReleaseCatNumbersJson = (rows: AddReleaseFormCatNumbersInputs) =>
   );
 
 const catNumberRowToJson = (row: CatalogueNumberRowState) => {
-  const labels = row.labelInputValues.map((entry) => entry.name);
-  const catNumbers = row.catalogueNumberInputValues.map((entry) => entry.value);
+  const labels = collectNonEmptyValues(
+    row.labelInputValues.map((entry) => entry.name),
+  );
+  const labelEntry = singleOrArrayEntry(labels, "label");
+
+  if (row.shape === "flat") {
+    const catNumbers = collectNonEmptyValues(
+      row.catalogueNumberInputValues.map((entry) => entry.value),
+    );
+
+    return {
+      ...labelEntry,
+      ...singleOrArrayEntry(catNumbers, "cat_number"),
+    };
+  }
+
+  const europe = collectNonEmptyValues(
+    row.europeCatalogueNumberInputValues.map((entry) => entry.value),
+  );
+  const uk = collectNonEmptyValues(
+    row.ukCatalogueNumberInputValues.map((entry) => entry.value),
+  );
+
+  const europeJson = singleOrArrayOrNull(europe);
+  const ukJson = singleOrArrayOrNull(uk);
+
+  if (europeJson === null || ukJson === null) {
+    // Validator forbids this; falling back to labels-only keeps the row
+    // structurally valid against the DB schema if it somehow slips through.
+    return labelEntry;
+  }
 
   return {
-    ...singleOrArrayEntry(labels, "label"),
-    ...singleOrArrayEntry(catNumbers, "cat_number"),
+    ...labelEntry,
+    cat_numbers: { "in Europe": europeJson, "in UK": ukJson },
   };
+};
+
+// Trims each value and drops empties so a stray placeholder input (e.g. the
+// default empty cat-number slot the user left untouched on a labels-only row)
+// doesn't leak into the JSON.
+const collectNonEmptyValues = (values: string[]): string[] => {
+  const result: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value.trim();
+
+    if (trimmed.length > 0) {
+      result.push(trimmed);
+    }
+  }
+
+  return result;
 };
 
 const singleOrArrayEntry = (

--- a/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/catalogueNumbers.ts
+++ b/src/app/windows/entry/Entry/AddReleaseForm/addReleaseFormUtils/validation/catalogueNumbers.ts
@@ -39,16 +39,13 @@ export const validateReleaseCatNumbers = (
   };
 };
 
+// Each present input must carry a non-empty value: a row can opt out of a
+// whole column (by having zero inputs in it), but an empty input slot inside
+// a column is never valid — the user must either fill it in or remove it.
 const labelInputValuesSchema = uniquePropertyArraySchema(
   z.object({
     id: z.string(),
-    name: z
-      .string()
-      .trim()
-      .min(
-        1,
-        "Label is required (or remove catalogue number section all together)",
-      ),
+    name: z.string().trim().min(1, "Fill in this label or remove the slot"),
   }),
   "Label names must be unique",
   [""],
@@ -61,19 +58,44 @@ const catalogueNumberInputValuesSchema = uniquePropertyArraySchema(
     value: z
       .string()
       .trim()
-      .min(
-        1,
-        "Value for catalogue number is required (or remove catalogue number section all together)",
-      ),
+      .min(1, "Fill in this catalogue number or remove the slot"),
   }),
   "Catalogue number values must be unique",
   [""],
   "value",
 );
 
-const catalogueNumberRowSchema = z
+// europeUk rows are stricter — the DB schema requires both regions to carry
+// at least one non-empty value — so each input's value is required and each
+// region's array must be non-empty.
+const regionCatNumberInputValuesSchema = (
+  requiredMessage: string,
+  uniqueMessage: string,
+) =>
+  uniquePropertyArraySchema(
+    z.object({
+      id: z.string(),
+      value: z.string().trim().min(1, requiredMessage),
+    }),
+    uniqueMessage,
+    [""],
+    "value",
+  );
+
+const europeCatNumberInputValuesSchema = regionCatNumberInputValuesSchema(
+  'Fill in this "in Europe" catalogue number or remove the slot',
+  '"In Europe" catalogue number values must be unique',
+).min(1, '"In Europe" needs at least one catalogue number value');
+
+const ukCatNumberInputValuesSchema = regionCatNumberInputValuesSchema(
+  'Fill in this "in UK" catalogue number or remove the slot',
+  '"In UK" catalogue number values must be unique',
+).min(1, '"In UK" needs at least one catalogue number value');
+
+const flatRowSchema = z
   .object({
     id: z.string(),
+    shape: z.literal("flat"),
     labelInputValues: labelInputValuesSchema,
     catalogueNumberInputValues: catalogueNumberInputValuesSchema,
   })
@@ -85,6 +107,19 @@ const catalogueNumberRowSchema = z
         "Each catalogue row needs at least one label or catalogue number field",
     },
   );
+
+const europeUkRowSchema = z.object({
+  id: z.string(),
+  shape: z.literal("europeUk"),
+  labelInputValues: labelInputValuesSchema,
+  europeCatalogueNumberInputValues: europeCatNumberInputValuesSchema,
+  ukCatalogueNumberInputValues: ukCatNumberInputValuesSchema,
+});
+
+const catalogueNumberRowSchema = z.discriminatedUnion("shape", [
+  flatRowSchema,
+  europeUkRowSchema,
+]);
 
 const catNumbersSchema = z.array(catalogueNumberRowSchema).optional();
 
@@ -116,13 +151,15 @@ const getCatNumbersFormFieldErrors = (
 
     const fieldKey = path[1];
 
+    const inputValueBucket = catNumberInputValueBucketFor(fieldKey);
+
     const addReleaseFormCatalogueNumberRowErrorsKey:
       | keyof AddReleaseFormCatalogueNumberRowErrors
       | undefined =
       fieldKey === "labelInputValues"
         ? "labelInputErrorMessages"
-        : fieldKey === "catalogueNumberInputValues"
-          ? "catNumberInputErrorMessages"
+        : inputValueBucket
+          ? inputValueBucket.errorMessagesKey
           : fieldKey === undefined
             ? "rowErrorMessages"
             : undefined;
@@ -136,6 +173,8 @@ const getCatNumbersFormFieldErrors = (
       errorMessagesMap[catNumbersRowById.id] ?? {
         labelInputErrorMessages: {},
         catNumberInputErrorMessages: {},
+        europeCatNumberInputErrorMessages: {},
+        ukCatNumberInputErrorMessages: {},
         rowErrorMessages: new Set(),
       };
 
@@ -170,38 +209,27 @@ const getCatNumbersFormFieldErrors = (
 
       rowErrorMessages.labelInputErrorMessages[labelInputId] =
         labelInputErrorMessages;
-    } else if (fieldKey === "catalogueNumberInputValues") {
+    } else if (inputValueBucket) {
       const catalogueNumberInputIndex = path[2];
 
       if (typeof catalogueNumberInputIndex !== "number") {
         continue;
       }
 
+      const inputsOnRow = inputValueBucket.readInputs(catNumbersRowById);
       const catalogueNumberInputId =
-        catNumbersRowById.catalogueNumberInputValues[catalogueNumberInputIndex]
-          ?.id;
+        inputsOnRow?.[catalogueNumberInputIndex]?.id;
 
       if (!catalogueNumberInputId) {
         continue;
       }
 
-      // error messages that belong to row's catalogue number inputs
-      const catNumberInputsErrorMessages =
-        rowErrorMessages.catNumberInputErrorMessages;
-
-      // error messages that belong to this particular catalogue number input
-      const catNumberInputErrorMessages =
-        catNumberInputsErrorMessages[catalogueNumberInputId] ?? new Set();
-
-      catNumberInputErrorMessages.add(message);
-
-      rowErrorMessages.catNumberInputErrorMessages = {
-        ...catNumberInputsErrorMessages,
-        [catalogueNumberInputId]: catNumberInputErrorMessages,
-      };
-
-      rowErrorMessages.catNumberInputErrorMessages[catalogueNumberInputId] =
-        catNumberInputErrorMessages;
+      addInputErrorToBucket(
+        rowErrorMessages,
+        inputValueBucket.errorMessagesKey,
+        catalogueNumberInputId,
+        message,
+      );
     } else {
       // error messages that belong to the whole row
       rowErrorMessages.rowErrorMessages.add(message);
@@ -211,4 +239,95 @@ const getCatNumbersFormFieldErrors = (
   }
 
   return errorMessagesMap;
+};
+
+// Maps the zod path head for the cat-number side of a row to the row-state
+// array it points at and the matching row-errors bucket.
+type CatNumberInputErrorMessagesKey = keyof Pick<
+  AddReleaseFormCatalogueNumberRowErrors,
+  | "catNumberInputErrorMessages"
+  | "europeCatNumberInputErrorMessages"
+  | "ukCatNumberInputErrorMessages"
+>;
+
+type CatNumberInputValueBucket = {
+  errorMessagesKey: CatNumberInputErrorMessagesKey;
+  readInputs: (
+    row: AddReleaseFormCatNumbersInputs[number],
+  ) => { id: string; value: string }[] | undefined;
+};
+
+const addInputErrorToBucket = (
+  rowErrors: AddReleaseFormCatalogueNumberRowErrors,
+  bucketKey: CatNumberInputErrorMessagesKey,
+  inputId: string,
+  message: string,
+) => {
+  switch (bucketKey) {
+    case "catNumberInputErrorMessages":
+      rowErrors.catNumberInputErrorMessages = withInputMessage(
+        rowErrors.catNumberInputErrorMessages,
+        inputId,
+        message,
+      );
+
+      return;
+    case "europeCatNumberInputErrorMessages":
+      rowErrors.europeCatNumberInputErrorMessages = withInputMessage(
+        rowErrors.europeCatNumberInputErrorMessages,
+        inputId,
+        message,
+      );
+
+      return;
+    case "ukCatNumberInputErrorMessages":
+      rowErrors.ukCatNumberInputErrorMessages = withInputMessage(
+        rowErrors.ukCatNumberInputErrorMessages,
+        inputId,
+        message,
+      );
+  }
+};
+
+const withInputMessage = (
+  bucket: Record<string, Set<string>>,
+  inputId: string,
+  message: string,
+): Record<string, Set<string>> => {
+  const set = bucket[inputId] ?? new Set<string>();
+  set.add(message);
+
+  return { ...bucket, [inputId]: set };
+};
+
+const catNumberInputValueBucketFor = (
+  fieldKey: PropertyKey | undefined,
+): CatNumberInputValueBucket | undefined => {
+  if (fieldKey === "catalogueNumberInputValues") {
+    return {
+      errorMessagesKey: "catNumberInputErrorMessages",
+      readInputs: (row) =>
+        row.shape === "flat" ? row.catalogueNumberInputValues : undefined,
+    };
+  }
+
+  if (fieldKey === "europeCatalogueNumberInputValues") {
+    return {
+      errorMessagesKey: "europeCatNumberInputErrorMessages",
+      readInputs: (row) =>
+        row.shape === "europeUk"
+          ? row.europeCatalogueNumberInputValues
+          : undefined,
+    };
+  }
+
+  if (fieldKey === "ukCatalogueNumberInputValues") {
+    return {
+      errorMessagesKey: "ukCatNumberInputErrorMessages",
+      readInputs: (row) =>
+        row.shape === "europeUk" ? row.ukCatalogueNumberInputValues : undefined,
+    };
+  }
+
+  return undefined;
 };


### PR DESCRIPTION
Extend the catalogue-numbers section so each row can switch between the flat shape (cat_numbers: string | string[]) and the Europe/UK regional shape (cat_numbers: { "in Europe", "in UK" }), driven by a per-row "Catalogue numbers shape" toggle.

Form state, validation, serialization and UI:
- CatalogueNumberRowState is now a discriminated union on "shape"; toEuropeUkRow / toFlatRow preserve labels and migrate values across the toggle, seeding empty inputs on both regions when needed so the user cannot land in an invalid empty-region state.
- validateReleaseCatNumbers uses z.discriminatedUnion("shape", ...) and maps errors into separate europeCatNumberInputErrorMessages and ukCatNumberInputErrorMessages buckets; empty per-item values are rejected with messages that mention "fill in or remove the slot", while the Europe/UK region arrays additionally require .min(1).
- toReleaseCatNumbersJson branches on row.shape and emits the regional object for europeUk rows; trims and drops empty values defensively.
- New CatalogueNumberInputColumn renders the per-column inputs and the "+ Add another ..." button under a single column heading; each row stacks Labels, the shape toggle, and the cat-number section(s) full width, with the UK section above Europe.
- "+ Add another ..." buttons are always visible; per-region remove crosses are hidden on the last input of each Europe/UK region so the invalid empty-region state is unreachable via the UI.

Tests: added toMusicalReleaseInsertValues cases for Europe/UK row combinations (single, multi, mixed with flat) and for stray empty-string inputs.